### PR TITLE
Add basic search in new tab

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -40,7 +40,7 @@ const manifest = withSidePanel({
   version: packageJson.version,
   description: '__MSG_extensionDescription__',
   host_permissions: ['<all_urls>'],
-  permissions: ['storage', 'scripting', 'tabs', 'notifications', 'bookmarks'],
+  permissions: ['storage', 'scripting', 'tabs', 'notifications', 'bookmarks', 'history'],
   options_page: 'options/index.html',
   background: {
     service_worker: 'background.iife.js',

--- a/packages/storage/lib/impl/bookmarkPathStorage.ts
+++ b/packages/storage/lib/impl/bookmarkPathStorage.ts
@@ -1,0 +1,17 @@
+import { StorageEnum } from '../base/enums';
+import { createStorage } from '../base/base';
+import type { BaseStorage } from '../base/types';
+
+export type BookmarkPathStorage = BaseStorage<string>;
+
+/**
+ * Stores a path (e.g. "Bookmarks Bar/Folder") to search for bookmarks under.
+ */
+export const bookmarkPathStorage: BookmarkPathStorage = createStorage<string>(
+  'bookmark-path',
+  '',
+  {
+    storageEnum: StorageEnum.Local,
+    liveUpdate: true,
+  },
+);

--- a/packages/storage/lib/impl/index.ts
+++ b/packages/storage/lib/impl/index.ts
@@ -1,1 +1,3 @@
 export * from './exampleThemeStorage';
+
+export * from "./bookmarkPathStorage";

--- a/pages/new-tab/src/NewTab.tsx
+++ b/pages/new-tab/src/NewTab.tsx
@@ -1,17 +1,23 @@
 import '@src/NewTab.css';
 import '@src/NewTab.scss';
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { t } from '@extension/i18n';
-import BookmarkList from './BookmarkList';
+import { useStorage } from '@extension/shared';
+import { bookmarkPathStorage } from '@extension/storage';
 
-const fetchBookmarks = () => {
+interface BookmarkItem {
+  title: string;
+  url: string;
+}
+
+const fetchBookmarkTree = () => {
   return new Promise<chrome.bookmarks.BookmarkTreeNode[]>((resolve, reject) => {
     if (chrome && chrome.bookmarks) {
-      chrome.bookmarks.getTree(bookmarkTree => {
+      chrome.bookmarks.getTree(tree => {
         if (chrome.runtime.lastError) {
           reject(chrome.runtime.lastError);
         } else {
-          resolve(bookmarkTree);
+          resolve(tree);
         }
       });
     } else {
@@ -20,35 +26,124 @@ const fetchBookmarks = () => {
   });
 };
 
+const fetchHistory = () => {
+  return new Promise<chrome.history.HistoryItem[]>(resolve => {
+    if (chrome && chrome.history) {
+      chrome.history.search({ text: '', maxResults: 100 }, items => {
+        resolve(items);
+      });
+    } else {
+      resolve([]);
+    }
+  });
+};
+
+function flattenBookmarks(nodes: chrome.bookmarks.BookmarkTreeNode[]): BookmarkItem[] {
+  const flat: BookmarkItem[] = [];
+  nodes.forEach(n => {
+    if (n.url) {
+      flat.push({ title: n.title, url: n.url });
+    }
+    if (n.children) {
+      flat.push(...flattenBookmarks(n.children));
+    }
+  });
+  return flat;
+}
+
+function findFolderByPath(tree: chrome.bookmarks.BookmarkTreeNode[], path: string): chrome.bookmarks.BookmarkTreeNode[] {
+  if (!path) return tree;
+  const segments = path.split('/').map(s => s.trim()).filter(Boolean);
+  let nodes = tree;
+  for (const seg of segments) {
+    const found = nodes.flatMap(n => n.children ?? []).find(n => n.title === seg && n.children);
+    if (found && found.children) {
+      nodes = [found];
+    } else {
+      return [];
+    }
+  }
+  return nodes[0].children ?? [];
+}
+
 const NewTab = () => {
-  const [bookmarks, setBookmarks] = useState<chrome.bookmarks.BookmarkTreeNode[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
+  const searchInput = useRef<HTMLInputElement>(null);
+  const bookmarkPath = useStorage(bookmarkPathStorage);
+  const [bookmarks, setBookmarks] = useState<BookmarkItem[]>([]);
+  const [history, setHistory] = useState<BookmarkItem[]>([]);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<BookmarkItem[]>([]);
+  const [highlight, setHighlight] = useState(0);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchBookmarks()
-      .then(bookmarkTree => {
-        setBookmarks(bookmarkTree);
-        setLoading(false);
-      })
-      .catch(error => {
-        console.error('북마크 로드 실패:', error);
-        setLoading(false);
-      });
+    searchInput.current?.focus();
   }, []);
 
+  useEffect(() => {
+    Promise.all([fetchBookmarkTree(), fetchHistory()]).then(([tree, his]) => {
+      const folderNodes = findFolderByPath(tree, bookmarkPath);
+      setBookmarks(flattenBookmarks(folderNodes));
+      setHistory(his.map(h => ({ title: h.title || h.url, url: h.url! })));
+      setLoading(false);
+    });
+  }, [bookmarkPath]);
+
+  useEffect(() => {
+    const lower = query.toLowerCase();
+    const items = [...history, ...bookmarks].filter(i =>
+      `${i.title} ${i.url}`.toLowerCase().includes(lower),
+    );
+    setResults(items);
+    setHighlight(0);
+  }, [query, history, bookmarks]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlight(h => Math.min(h + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlight(h => Math.max(h - 1, 0));
+    } else if (e.key === 'Enter') {
+      const url = results[highlight]?.url;
+      if (url) {
+        window.location.href = url;
+      }
+    }
+  };
+
   return (
-    <div className={`App`}>
+    <div className="App">
       <header className="App-header">
         <div className="mb-6 flex w-full justify-center">
           <input
+            ref={searchInput}
             type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="검색..."
             className="w-2/3 rounded-full bg-white p-3 text-gray-700 shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 md:w-1/2 lg:w-1/3"
           />
         </div>
-
-        <h6>북마크 목록</h6>
-        {loading ? <div>{t('loading')}</div> : <BookmarkList bookmarks={bookmarks} />}
+        {loading ? (
+          <div>{t('loading')}</div>
+        ) : (
+          <div className="w-full max-w-xl mx-auto text-left">
+            {results.map((r, idx) => (
+              <div
+                key={`${r.url}-${idx}`}
+                className={`px-2 py-1 ${idx === highlight ? 'bg-blue-100' : ''}`}
+              >
+                <a href={r.url} className="text-blue-600 hover:underline" onClick={e => e.preventDefault()}>
+                  {r.title}
+                </a>
+                <span className="ml-2 text-xs text-gray-500">{r.url}</span>
+              </div>
+            ))}
+          </div>
+        )}
       </header>
     </div>
   );

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -1,10 +1,11 @@
 import '@src/Options.css';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
-import { exampleThemeStorage } from '@extension/storage';
+import { exampleThemeStorage, bookmarkPathStorage } from '@extension/storage';
 import { Button } from '@extension/ui';
 
 const Options = () => {
   const theme = useStorage(exampleThemeStorage);
+  const bookmarkPath = useStorage(bookmarkPathStorage);
   const isLight = theme === 'light';
   const logo = isLight ? 'options/logo_horizontal.svg' : 'options/logo_horizontal_dark.svg';
   const goGithubSite = () =>
@@ -15,9 +16,16 @@ const Options = () => {
       <button onClick={goGithubSite}>
         <img src={chrome.runtime.getURL(logo)} className="App-logo" alt="logo" />
       </button>
-      <p>
-        Edit <code>pages/options/src/Options.tsx</code>
-      </p>
+      <div className="my-4 text-left">
+        <label className="block text-sm mb-2">Bookmark search path</label>
+        <input
+          value={bookmarkPath}
+          onChange={e => bookmarkPathStorage.set(e.target.value)}
+          placeholder="e.g. Bookmarks Bar/Work"
+          className="w-full rounded border px-2 py-1 text-black"
+          type="text"
+        />
+      </div>
       <Button className="mt-4" onClick={exampleThemeStorage.toggle} theme={theme}>
         Toggle theme
       </Button>


### PR DESCRIPTION
## Summary
- store bookmark search path in extension storage
- allow editing bookmark search path in options page
- add history permission
- implement search for bookmarks and history on new tab

## Testing
- `pnpm -F chrome-extension test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edcd42730832dba5f809bfe1cd424