### PR TITLE
Add bookmark path translation

### DIFF
--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -13,6 +13,12 @@
   "loading": {
     "message": "Loading..."
   },
+  "bookmarkSearchPath": {
+    "message": "Bookmark search path"
+  },
+  "bookmarkSearchPathPlaceholder": {
+    "message": "e.g. Bookmarks Bar/Work"
+  },
   "greeting": {
     "description": "Greeting message",
     "message": "Hello, My name is $NAME$",

--- a/packages/i18n/locales/ko/messages.json
+++ b/packages/i18n/locales/ko/messages.json
@@ -13,6 +13,12 @@
   "loading": {
     "message": "로딩 중..."
   },
+  "bookmarkSearchPath": {
+    "message": "북마크 검색 경로"
+  },
+  "bookmarkSearchPathPlaceholder": {
+    "message": "예: 북마크 바/작업"
+  },
   "greeting": {
     "description": "인사 메시지",
     "message": "안녕하세요, 제 이름은 $NAME$입니다.",

--- a/pages/new-tab/src/BookmarkList.tsx
+++ b/pages/new-tab/src/BookmarkList.tsx
@@ -27,7 +27,7 @@ const BookmarkList: React.FC<BookmarkProps> = ({ bookmarks }) => {
         <a href={bookmark.url} target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">
           {bookmark.title}
         </a>
-        <span className="text-gray-500 text-sm truncate max-w-xs" title={bookmark.url}>
+        <span className="max-w-xs truncate text-sm text-gray-500" title={bookmark.url}>
           {bookmark.url}
         </span>
       </div>

--- a/pages/new-tab/src/NewTab.tsx
+++ b/pages/new-tab/src/NewTab.tsx
@@ -51,9 +51,15 @@ function flattenBookmarks(nodes: chrome.bookmarks.BookmarkTreeNode[]): BookmarkI
   return flat;
 }
 
-function findFolderByPath(tree: chrome.bookmarks.BookmarkTreeNode[], path: string): chrome.bookmarks.BookmarkTreeNode[] {
+function findFolderByPath(
+  tree: chrome.bookmarks.BookmarkTreeNode[],
+  path: string,
+): chrome.bookmarks.BookmarkTreeNode[] {
   if (!path) return tree;
-  const segments = path.split('/').map(s => s.trim()).filter(Boolean);
+  const segments = path
+    .split('/')
+    .map(s => s.trim())
+    .filter(Boolean);
   let nodes = tree;
   for (const seg of segments) {
     const found = nodes.flatMap(n => n.children ?? []).find(n => n.title === seg && n.children);
@@ -84,16 +90,14 @@ const NewTab = () => {
     Promise.all([fetchBookmarkTree(), fetchHistory()]).then(([tree, his]) => {
       const folderNodes = findFolderByPath(tree, bookmarkPath);
       setBookmarks(flattenBookmarks(folderNodes));
-      setHistory(his.map(h => ({ title: h.title || h.url, url: h.url! })));
+      setHistory(his.map(h => ({ title: h.title || h.url!, url: h.url! })));
       setLoading(false);
     });
   }, [bookmarkPath]);
 
   useEffect(() => {
     const lower = query.toLowerCase();
-    const items = [...history, ...bookmarks].filter(i =>
-      `${i.title} ${i.url}`.toLowerCase().includes(lower),
-    );
+    const items = [...history, ...bookmarks].filter(i => `${i.title} ${i.url}`.toLowerCase().includes(lower));
     setResults(items);
     setHighlight(0);
   }, [query, history, bookmarks]);
@@ -130,12 +134,9 @@ const NewTab = () => {
         {loading ? (
           <div>{t('loading')}</div>
         ) : (
-          <div className="w-full max-w-xl mx-auto text-left">
+          <div className="mx-auto w-full max-w-xl text-left">
             {results.map((r, idx) => (
-              <div
-                key={`${r.url}-${idx}`}
-                className={`px-2 py-1 ${idx === highlight ? 'bg-blue-100' : ''}`}
-              >
+              <div key={`${r.url}-${idx}`} className={`px-2 py-1 ${idx === highlight ? 'bg-blue-100' : ''}`}>
                 <a href={r.url} className="text-blue-600 hover:underline" onClick={e => e.preventDefault()}>
                   {r.title}
                 </a>

--- a/pages/options/package.json
+++ b/pages/options/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@extension/shared": "workspace:*",
     "@extension/storage": "workspace:*",
-    "@extension/ui": "workspace:*"
+    "@extension/ui": "workspace:*",
+    "@extension/i18n": "workspace:*"
   },
   "devDependencies": {
     "@extension/tailwindcss-config": "workspace:*",

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -2,6 +2,7 @@ import '@src/Options.css';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
 import { exampleThemeStorage, bookmarkPathStorage } from '@extension/storage';
 import { Button } from '@extension/ui';
+import { t } from '@extension/i18n';
 
 const Options = () => {
   const theme = useStorage(exampleThemeStorage);
@@ -17,11 +18,14 @@ const Options = () => {
         <img src={chrome.runtime.getURL(logo)} className="App-logo" alt="logo" />
       </button>
       <div className="my-4 text-left">
-        <label className="block text-sm mb-2">Bookmark search path</label>
+        <label htmlFor="bookmarkPath" className="mb-2 block text-sm">
+          {t('bookmarkSearchPath')}
+        </label>
         <input
+          id="bookmarkPath"
           value={bookmarkPath}
           onChange={e => bookmarkPathStorage.set(e.target.value)}
-          placeholder="e.g. Bookmarks Bar/Work"
+          placeholder={t('bookmarkSearchPathPlaceholder')}
           className="w-full rounded border px-2 py-1 text-black"
           type="text"
         />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
 
   pages/options:
     dependencies:
+      '@extension/i18n':
+        specifier: workspace:*
+        version: link:../../packages/i18n
       '@extension/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## Summary
- localize bookmark search path label and placeholder
- register i18n package for options page
- fix Typescript warning in bookmark history fetch
- lint fixes

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_684ef29b3230832d931e6c24a845af07